### PR TITLE
spdlog 1.11.0

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,2 +1,0 @@
-channels:
-  - sk_test

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,2 @@
+channels:
+  - sk_test

--- a/recipe/bld_std.bat
+++ b/recipe/bld_std.bat
@@ -1,10 +1,11 @@
 :: cmd
+echo "Building %PKG_NAME%."
 
 
 :: Isolate the build.
-mkdir Build
-cd Build
-if errorlevel 1 exit 1
+mkdir Build-%PKG_NAME%
+cd Build-%PKG_NAME%
+if errorlevel 1 exit /b 1
 
 
 :: Generate the build files.

--- a/recipe/build_std.sh
+++ b/recipe/build_std.sh
@@ -1,9 +1,10 @@
 #!/bin/bash
+echo "Building ${PKG_NAME}."
 
 
 # Isolate the build.
-mkdir -p Build
-cd Build || exit 1
+mkdir -p Build-${PKG_NAME}
+cd Build-${PKG_NAME} || exit 1
 
 
 # Generate the build files.

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
-{% set version = "1.9.2" %}
-{% set sha256 = "6fff9215f5cb81760be4cc16d033526d1080427d236e86d70bb02994f85e3d38" %}
+{% set version = "1.11.0" %}
+{% set sha256 = "ca5cae8d6cac15dae0ec63b21d6ad3530070650f68076f3a4a862ca293a858bb" %}
 {% set build_number = "0" %}
 
 package:
@@ -37,7 +37,7 @@ outputs:
         - {{ compiler('cxx') }}
         - ninja
       host:
-        - fmt >=8.1.1
+        - fmt 9.1.0
     test:
       commands:
         - test -e $PREFIX/include/spdlog/spdlog.h  # [unix]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -40,7 +40,7 @@ outputs:
         - fmt 9.1.0
     test:
       commands:
-        - test -e $PREFIX/include/spdlog/spdlog.h  # [unix]
+        - test -e $PREFIX/include/spdlog/spdlog.h                       # [unix]
         - if not exist %PREFIX%\Library\include\spdlog\spdlog.h exit 1  # [win]
   # Built in the historic conda-forge way.
   - name: spdlog-fmt-embed
@@ -58,7 +58,7 @@ outputs:
         - ninja
     test:
       commands:
-        - test -e $PREFIX/include/spdlog/spdlog.h  # [unix]
+        - test -e $PREFIX/include/spdlog/spdlog.h                       # [unix]
         - if not exist %PREFIX%\Library\include\spdlog\spdlog.h exit 1  # [win]
 
 about:


### PR DESCRIPTION
Changelog: https://github.com/gabime/spdlog/releases
License: https://github.com/gabime/spdlog/blob/v1.11.0/LICENSE
Requirements:
- https://github.com/gabime/spdlog/blob/v1.11.0/CMakeLists.txt
- https://github.com/gabime/spdlog/blob/v1.11.0/INSTALL

Actions:
1. Enhance readability: add comments to `build.sh` and `bld.bat`, fix exits
2. Add pinning to `host`: `fmt 9.1.0`

Notes:

- The downstream package `libmamba 1.3.0` requires `styled` https://fmt.dev/9.1.0/api.html#_CPPv4I0EN3fmt6styledEN6detail10styled_argI14remove_cvref_tI1TEEERK1T10text_style missing in the current `fmt 8.1.1`, so we update `fmt` to **9.1.0** https://github.com/AnacondaRecipes/fmt-feedstock/pull/4.
But the current version **1.9.2** of spdlog has `fmt` with pinning `8.1.1`.
- For building `libmamba 1.3.0` conda-forge uses `fmt 9.1.0` and `spglog 1.11.0`, see https://dev.azure.com/conda-forge/feedstock-builds/_build/results?buildId=652819&view=logs&j=ced5d8de-8227-5f3f-33a1-45cf1592c45a&t=f7bcb349-6dca-53ba-d88d-1d9963e119ba
- packages that depend on `fmt`: 
  - `libmamba`, `libmambapy`, and `spdlog` have pinning `fmt >=8.1.1,<9.0a0`,
  - `omniscidb`, `omniscidb-common`, `omniscidbe`, and `pyomniscidbe` have pinning `fmt >=7.1.3,<8.0a0` https://metayaml-conda.fly.dev/metayaml/reverse_dependencies?name=fmt