### PR TITLE
Update version to 1.16.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,12 +1,13 @@
-{% set version = "1.15.3" %}
+{% set version = "1.16.0" %}
+{% set name = "spdlog" %}
 
 package:
-  name: spdlog-split
+  name: {{ name }}-split
   version: {{ version }}
 
 source:
-  url: https://github.com/gabime/spdlog/archive/v{{ version }}.tar.gz
-  sha256: 15a04e69c222eb6c01094b5c7ff8a249b36bb22788d72519646fb85feb267e67
+  url: https://github.com/gabime/{{ name }}/archive/v{{ version }}.tar.gz
+  sha256: 8741753e488a78dd0d0024c980e1fb5b5c85888447e309d9cb9d949bdb52aa3e
   patches:
     - async_test.patch  # [win]  Simple workaround for async issue. It looks like the code works, but the test result is inconsistent.
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -23,8 +23,6 @@ outputs:
     build:
       run_exports:
         - {{ pin_subpackage('spdlog', max_pin='x') }}
-      missing_dso_whitelist:  # [s390x]
-        - $RPATH/ld64.so.1    # [s390x] Know s390x `ld64.so` issue.
     requirements:
       build:
         - cmake
@@ -33,7 +31,7 @@ outputs:
         - ninja
         # Tests are using catch2 which is unavailable on the main channel,
         # using vendored one instead
-        - git  # [linux]
+        - git
       host:
         - fmt 11.2.0
     test:
@@ -55,7 +53,7 @@ outputs:
         - {{ stdlib('c') }}
         - {{ compiler('cxx') }}
         - ninja
-        - git  # [linux]
+        - git
     test:
       commands:
         - test -e $PREFIX/include/spdlog/spdlog.h                       # [unix]


### PR DESCRIPTION
spdlog 1.16.0

**Destination channel:** defaults

### Links

- [PKG-11366](https://anaconda.atlassian.net/browse/PKG-11366) 
- [Upstream repository](https://github.com/gabime/spdlog)

### Explanation of changes:

- new version number


[PKG-11366]: https://anaconda.atlassian.net/browse/PKG-11366?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ